### PR TITLE
Add optional command line arguments in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ The default storage location is the user’s home directory, and the date and ti
 ### Optional command line arguments
 Each of the following arguments can be appended to the above roslaunch-commands with `argument:=value`.
 
-| Argument                       |                                                                        Description        |
-|--------------------------------|:-----------------------------------------------------------------------------------------:|
-| `max_range`                    | Specifies the maximum range for the displayed range markers. By default it is set to 40m. |   
+| Argument                       |                                                                                                                                                  Description                                                                                                                                                   |
+|--------------------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|
+| `max_range`                    | Specifies the maximum range for the displayed range markers. The range markers will be displayed in 10m steps up to the largest number that is a multiple of 10 and smaller than the specified max range (e.g. if `max_range:=98` then the maximum displayed range will be 90m).  By default it is set to 40m. |   
 ## Useful ROS Commands
 
 | Command                                                                |                                                                                       Description                                                                                        |

--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ roslaunch zendar_ros_driver rosbag_save.launch output_name:=/home/zendar_data/re
 ```
 The default storage location is the user’s home directory, and the date and time of the recording will be appended to the file name.
 
+### Optional command line arguments
+Each of the following arguments can be appended to the above roslaunch-commands with `argument:=value`.
+
+| Argument                       |                                                                        Description        |
+|--------------------------------|:-----------------------------------------------------------------------------------------:|
+| `max_range`                    | Specifies the maximum range for the displayed range markers. By default it is set to 40m. |   
 ## Useful ROS Commands
 
 | Command                                                                |                                                                                       Description                                                                                        |


### PR DESCRIPTION
We should provide a (minimal) documentation of commandline arguments that can be added to the roslaunch-commands.   