### PR TITLE
DA-21/DA-57: Add visualization of object tracks

### DIFF
--- a/include/zendar_ros_driver/tracks.h
+++ b/include/zendar_ros_driver/tracks.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <visualization_msgs/MarkerArray.h>
+#include <geometry_msgs/Pose.h>
+#include <geometry_msgs/Point.h>
+#include <geometry_msgs/Quaternion.h>
+#include <zendar/api/api.h>
+
+namespace zen {
+visualization_msgs::MarkerArray Tracks(const zpb::drivable_area::Tracks& tracks);
+visualization_msgs::Marker CreateEdgeMsg(const zpb::drivable_area::Track& track,
+                                         int& edge_id);
+visualization_msgs::Marker CreateVelocityMsg(const zpb::drivable_area::Track& track);
+}  // namespace zen

--- a/include/zendar_ros_driver/tracks.h
+++ b/include/zendar_ros_driver/tracks.h
@@ -7,6 +7,15 @@
 #include <zendar/api/api.h>
 
 namespace zen {
+// Diameter of the bounding box edges
+static constexpr float EDGE_DIAMETER = 0.3;
+// Diameter of the velocity arrow's shaft
+static constexpr float Velocity_SHAFT_DIAMETER = 0.1;
+// Diameter of the velocity arrow's head
+static constexpr float Velocity_HEAD_DIAMETER = 0.3;
+// Length of the velocity arrow's head
+static constexpr float Velocity_HEAD_LENGTH = 0.3;
+
 visualization_msgs::MarkerArray Tracks(const zpb::drivable_area::Tracks& tracks);
 visualization_msgs::Marker CreateEdgeMsg(const zpb::drivable_area::Track& track,
                                          int& edge_id);

--- a/include/zendar_ros_driver/tracks.h
+++ b/include/zendar_ros_driver/tracks.h
@@ -10,11 +10,11 @@ namespace zen {
 // Diameter of the bounding box edges
 static constexpr float EDGE_DIAMETER = 0.3;
 // Diameter of the velocity arrow's shaft
-static constexpr float Velocity_SHAFT_DIAMETER = 0.1;
+static constexpr float VELOCITY_SHAFT_DIAMETER = 0.1;
 // Diameter of the velocity arrow's head
-static constexpr float Velocity_HEAD_DIAMETER = 0.3;
+static constexpr float VELOCITY_HEAD_DIAMETER = 0.3;
 // Length of the velocity arrow's head
-static constexpr float Velocity_HEAD_LENGTH = 0.3;
+static constexpr float VELOCITY_HEAD_LENGTH = 0.3;
 
 visualization_msgs::MarkerArray Tracks(const zpb::drivable_area::Tracks& tracks);
 visualization_msgs::Marker CreateEdgeMsg(const zpb::drivable_area::Track& track,

--- a/include/zendar_ros_driver/zendar_driver_node.h
+++ b/include/zendar_ros_driver/zendar_driver_node.h
@@ -10,6 +10,7 @@
 #include <sensor_msgs/PointCloud2.h>
 #include <nav_msgs/OccupancyGrid.h>
 #include <visualization_msgs/Marker.h>
+#include <visualization_msgs/MarkerArray.h>
 #include <tf2_ros/static_transform_broadcaster.h>
 
 /// \namespace -----------------------------------------------------------------
@@ -40,13 +41,13 @@ private:
   void ProcessRangeMarkers();
   void ProcessEgoVehicle();
   void ProcessOccupancyGrid();
+  void ProcessTracks();
 
   void ProcessHKGpsStatus(const zpb::telem::HousekeepingReport& report);
   void ProcessHKSensorIdentity(const zpb::telem::HousekeepingReport& report);
   void PublishExtrinsic(const zpb::telem::SensorIdentity& id);
   void PublishVehicleToMap();
 
-private:
   std::shared_ptr<ros::NodeHandle> node;
   image_transport::ImageTransport image_transport{*this->node};
 
@@ -60,6 +61,7 @@ private:
   ros::Publisher pose_quality_pub = this->node->advertise<diagnostic_msgs::DiagnosticArray>("/diagnostics", 100);
 
   ros::Publisher occupancy_grid_pub = this->node->advertise<nav_msgs::OccupancyGrid>("/occupancy_grid", 1);
+  ros::Publisher tracks_pub = this->node->advertise<visualization_msgs::MarkerArray>("/tracks", 100);
 
   // Create range marker, and ego vehicle publisher as latched topics
   ros::Publisher range_markers_pub

--- a/src/tracks.cc
+++ b/src/tracks.cc
@@ -102,7 +102,7 @@ CreateVelocityMsg(const zpb::drivable_area::Track& track) {
   // Define scale
   velocity_msg.scale.x = VELOCITY_SHAFT_DIAMETER;  // shaft diameter
   velocity_msg.scale.y = VELOCITY_HEAD_DIAMETER;  // head diameter
-  velocity_msg.scale.z = Velocity_HEAD_LENGTH;  // head length
+  velocity_msg.scale.z = VELOCITY_HEAD_LENGTH;  // head length
 
   // Define color
   velocity_msg.color.r = track.color().x();

--- a/src/tracks.cc
+++ b/src/tracks.cc
@@ -1,0 +1,131 @@
+#include "zendar_ros_driver/tracks.h"
+namespace zen {
+visualization_msgs::MarkerArray
+Tracks(const zpb::drivable_area::Tracks& tracks){
+  visualization_msgs::MarkerArray track_msgs;
+  for (const zpb::drivable_area::Track& track : tracks.track()) {
+    // Iterate over edges of bounding box (= bounding box visualization
+    // represented by list of edges msgs)
+    for (std::size_t edge_id = 0; edge_id < track.bbox_edges().size() - 1;
+         edge_id += 2)
+    {
+      edge_msg = CreateEdgeMsg(track, edge_id);
+      track_msgs.markers.push_back(edge_msg);
+    }
+    velocity_msg = CreateVelocityMsg(track);
+
+    track_msgs.markers.push_back(velocity_msg);
+  }
+  return track_msgs
+}
+
+visualization_msgs::Marker
+CreateEdgeMsg(const zpb::drivable_area::Track& track, int& edge_id) {
+  visualization_msgs::Marker edge_msg;
+
+  // Define header
+  edge_msg.header.frame_id = "map";
+  edge_msg.header.stamp = ros::Time::now();
+
+  edge_msg.ns = std::to_string(track.id());
+  edge_msg.id = edge_id;
+
+  // Define type of marker (0 = Arrow)
+  edge_msg.type = 0;
+  edge_msg.action = 0;
+  edge_msg.lifetime = ros::Duration(0);
+
+  // Define pose (Identity since the actual pose of the edge is specified by
+  // its start and end point)
+  geometry_msgs::Pose pose;
+  pose.position.x = 0;
+  pose.position.y = 0;
+  pose.position.z = 0;
+  pose.orientation.x = 0;
+  pose.orientation.y = 0;
+  pose.orientation.z = 0;
+  pose.orientation.w = 1;
+  edge_msg.pose = pose;
+
+  // Define scale (Only want shaft of arrow => Set head diameter/length to 0)
+  edge_msg.scale.x = 0.3;  // shaft diameter
+  edge_msg.scale.y = 0;  // head diameter
+  edge_msg.scale.z = 0;  // head length
+
+  // Define color for each line
+  std_msgs::ColorRGBA color_msg;
+  edge_msg.color.r = track.color().x();
+  edge_msg.color.g = track.color().y();
+  edge_msg.color.b = track.color().z();
+  edge_msg.color.a = 1;
+
+  // Define start and end of arrow
+  geometry_msgs::Point start_point_msg;
+  start_point_msg.x = track.bbox_edges()[edge_id].x();
+  start_point_msg.y = track.bbox_edges()[edge_id].y();
+  start_point_msg.z = track.bbox_edges()[edge_id].z();
+
+  // The next steps are needed to counteract the non-existing arrow head
+  std::vector<float> edge{0, 0, 0};
+  egde[0] = track.bbox_edges()[edge_id+1].x() - track.bbox_edges()[edge_id].x();
+  egde[1] = track.bbox_edges()[edge_id+1].y() - track.bbox_edges()[edge_id].y();
+  egde[2] = track.bbox_edges()[edge_id+1].z() - track.bbox_edges()[edge_id].z();
+
+  geometry_msgs::Point end_point_msg;
+  // The default shaft:head ratio in rviz is 1:0.3 (see rviz repo).
+  // Therefore, mulitply edge by the following scale factor to get an arrow
+  // only consisting of a body (without a head) the same length as the edge
+  float scale_factor = 1 / (1 - 0.3);
+  end_point_msg.x = track.bbox_edges()[edge_id].x() + scale_factor * edge[0];
+  end_point_msg.y = track.bbox_edges()[edge_id].y() + scale_factor * edge[1];
+  end_point_msg.z = track.bbox_edges()[edge_id].z() + scale_factor * edge[2];
+
+  edge_msg.points.push_back(start_point_msg);
+  edge_msg.points.push_back(end_point_msg);
+
+  return edge_msg;
+}
+
+visualization_msgs::Marker
+CreateVelocityMsg(const zpb::drivable_area::Track& track) {
+  visualization_msgs::Marker velocity_msg;
+
+  // Define header
+  velocity_msg.header.frame_id = "map";
+  velocity_msg.header.stamp =ros::Time::now();
+
+  // Define type of marker (0 = Arrow)
+  velocity_msg.type = 0;
+  velocity_msg.action = 0;
+  velocity_msg.lifetime = ros::Duration(0);
+  velocity_msg.ns = std::to_string(track.id());
+  velocity_msg.id = -1;
+
+  // Define scale
+  velocity_msg.scale.x = 0.1;  // shaft diameter
+  velocity_msg.scale.y = 0.3;  // head diameter
+  velocity_msg.scale.z = 0.3;  // head length
+
+  // Define color
+  velocity_msg.color.r = track.color().x();
+  velocity_msg.color.g = track.color().y();
+  velocity_msg.color.b = track.color().z();
+  velocity_msg.color.a = 1;
+
+  // Define start and end point of arrow
+  geometry_msgs::Point start_point_msg;
+  start_point_msg.x = track.bbox_center().x();
+  start_point_msg.y = track.bbox_center().y();
+  start_point_msg.z = track.bbox_center().z();
+
+  geometry_msgs::Point end_point_msg;
+  end_point_msg.x = track.bbox_center().x() + track.velocity().x();
+  end_point_msg.y = track.bbox_center().y() + track.velocity().y();
+  end_point_msg.z = track.bbox_center().z() + track.velocity().z();
+
+  velocity_msg.points.push_back(start_point_msg);
+  velocity_msg.points.push_back(end_point_msg);
+
+  return velocity_msg;
+}
+}  // namespace zen

--- a/src/tracks.cc
+++ b/src/tracks.cc
@@ -30,9 +30,8 @@ CreateEdgeMsg(const zpb::drivable_area::Track& track, int& edge_id) {
   edge_msg.ns = std::to_string(track.id());
   edge_msg.id = edge_id;
 
-  // Define type of marker (0 = Arrow)
-  edge_msg.type = 0;
-  edge_msg.action = 0;
+  edge_msg.type = visualization_msgs::Marker::ARROW;
+  edge_msg.action = visualization_msgs::Marker::ADD;
   edge_msg.lifetime = ros::Duration(0);
 
   // Define pose (Identity since the actual pose of the edge is specified by
@@ -94,9 +93,8 @@ CreateVelocityMsg(const zpb::drivable_area::Track& track) {
   velocity_msg.header.frame_id = "map";
   velocity_msg.header.stamp =ros::Time::now();
 
-  // Define type of marker (0 = Arrow)
-  velocity_msg.type = 0;
-  velocity_msg.action = 0;
+  velocity_msg.type = visualization_msgs::Marker::ARROW;
+  velocity_msg.action = visualization_msgs::Marker::ADD;
   velocity_msg.lifetime = ros::Duration(0);
   velocity_msg.ns = std::to_string(track.id());
   velocity_msg.id = -1;

--- a/src/tracks.cc
+++ b/src/tracks.cc
@@ -47,7 +47,7 @@ CreateEdgeMsg(const zpb::drivable_area::Track& track, int& edge_id) {
   edge_msg.pose = pose;
 
   // Define scale (Only want shaft of arrow => Set head diameter/length to 0)
-  edge_msg.scale.x = 0.3;  // shaft diameter
+  edge_msg.scale.x = EDGE_DIAMETER;  // shaft diameter
   edge_msg.scale.y = 0;  // head diameter
   edge_msg.scale.z = 0;  // head length
 
@@ -100,9 +100,9 @@ CreateVelocityMsg(const zpb::drivable_area::Track& track) {
   velocity_msg.id = -1;
 
   // Define scale
-  velocity_msg.scale.x = 0.1;  // shaft diameter
-  velocity_msg.scale.y = 0.3;  // head diameter
-  velocity_msg.scale.z = 0.3;  // head length
+  velocity_msg.scale.x = VELOCITY_SHAFT_DIAMETER;  // shaft diameter
+  velocity_msg.scale.y = VELOCITY_HEAD_DIAMETER;  // head diameter
+  velocity_msg.scale.z = Velocity_HEAD_LENGTH;  // head length
 
   // Define color
   velocity_msg.color.r = track.color().x();

--- a/src/zendar_driver_node.cc
+++ b/src/zendar_driver_node.cc
@@ -2,6 +2,7 @@
 #include "zendar_ros_driver/zendar_point.h"
 #include "zendar_ros_driver/range_markers.h"
 #include "zendar_ros_driver/ego_vehicle.h"
+#include "zendar_ros_driver/tracks.h"
 
 // #include <ros/ros.h>
 // #include <diagnostic_msgs/DiagnosticArray.h>
@@ -302,10 +303,19 @@ void ZendarDriverNode::Run()
     this->ProcessImages();
     this->ProcessPointClouds();
     this->ProcessOccupancyGrid();
+    this->ProcessTracks();
     this->ProcessPoseMessages();
     this->ProcessLogMessages();
     this->ProcessHousekeepingReports();
     loop_rate.sleep();
+  }
+}
+
+void ZendarDriverNode::ProcessTracks()
+{
+  while (auto tracks = ZenApi::NextTracks(ZenApi::NO_WAIT)) {
+    auto tracks_msg = Tracks(*tracks);
+    this->tracks_pub.publish(tracks_msg);
   }
 }
 
@@ -372,6 +382,7 @@ ZendarDriverNode::ProcessOccupancyGrid()
     this->occupancy_grid_pub.publish(ConvertToRosGrid(*occ_grid));
   }
 }
+
 void ZendarDriverNode::ProcessRangeMarkers()
 {
   auto range_markers = RangeMarkers(max_range);

--- a/src/zendar_driver_node.cc
+++ b/src/zendar_driver_node.cc
@@ -311,14 +311,6 @@ void ZendarDriverNode::Run()
   }
 }
 
-void ZendarDriverNode::ProcessTracks()
-{
-  while (auto tracks = ZenApi::NextTracks(ZenApi::NO_WAIT)) {
-    auto tracks_msg = Tracks(*tracks);
-    this->tracks_pub.publish(tracks_msg);
-  }
-}
-
 void ZendarDriverNode::ProcessImages()
 {
   while (auto image = ZenApi::NextImage(ZenApi::NO_WAIT)) {
@@ -380,6 +372,14 @@ ZendarDriverNode::ProcessOccupancyGrid()
 {
   while(auto occ_grid = ZenApi::NextOccupancyGrid(ZenApi::NO_WAIT)) {
     this->occupancy_grid_pub.publish(ConvertToRosGrid(*occ_grid));
+  }
+}
+
+void ZendarDriverNode::ProcessTracks()
+{
+  while (auto tracks = ZenApi::NextTracks(ZenApi::NO_WAIT)) {
+    auto tracks_msg = Tracks(*tracks);
+    this->tracks_pub.publish(tracks_msg);
   }
 }
 


### PR DESCRIPTION
This PR adds the option to visualize object tracks in the ROS driver. The tracks are visualized as unfilled cubes (only the edges are visible) that represent the outlines of the current bounding box of this specific track. Further, each track has a velocity represented as an arrow starting in the center of the bounding box. The following image shows an example of a track bounding box (unfilled blue cube) together with the ego-vehicle (green cube).
![image](https://user-images.githubusercontent.com/50847360/179035038-cbb8e143-9518-4312-b96c-68acc2a0396b.png)
